### PR TITLE
rpk/container: use 9093 for the external port for the kafka api

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -36,7 +36,8 @@ var (
 )
 
 const (
-	redpandaNetwork = "redpanda"
+	redpandaNetwork   = "redpanda"
+	externalKafkaPort = 9093
 
 	defaultDockerClientTimeout = 60 * time.Second
 )
@@ -134,7 +135,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 		return nil, err
 	}
 	hostKafkaPort, err := getHostPort(
-		config.DefaultKafkaPort,
+		externalKafkaPort,
 		containerJSON,
 	)
 	if err != nil {
@@ -224,7 +225,7 @@ func CreateNode(
 	}
 	kPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.DefaultKafkaPort),
+		strconv.Itoa(int(externalKafkaPort)),
 	)
 	if err != nil {
 		return nil, err
@@ -253,7 +254,7 @@ func CreateNode(
 		"--node-id",
 		fmt.Sprintf("%d", nodeID),
 		"--kafka-addr",
-		ListenAddresses(ip, config.DefaultKafkaPort, kafkaPort),
+		ListenAddresses(ip, config.DefaultKafkaPort, externalKafkaPort),
 		"--pandaproxy-addr",
 		ListenAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--rpc-addr",

--- a/src/go/rpk/pkg/cli/cmd/container/common/test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/test.go
@@ -243,7 +243,7 @@ func (c *MockClient) IsErrConnectionFailed(err error) bool {
 func MockContainerInspect(
 	_ context.Context, _ string,
 ) (types.ContainerJSON, error) {
-	kafkaNatPort := nat.Port("9092/tcp")
+	kafkaNatPort := nat.Port("9093/tcp")
 	rpcNatPort := nat.Port("33145/tcp")
 	return types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{


### PR DESCRIPTION
The port being mapped by docker is now port 9093 and port 9092 is for
internal use, like by prandaproxy or coproc.